### PR TITLE
Update workflows and clean up flake.lock

### DIFF
--- a/.github/workflows/flake.yaml
+++ b/.github/workflows/flake.yaml
@@ -43,8 +43,9 @@ jobs:
           name: altf4llc-os
       - uses: actions/checkout@v4
       - run: cachix use "altf4llc-os"
-      - run: |
-          nix develop -c just build "${{ matrix.profile }}"
+      - run: nix develop -c just build "${{ matrix.profile }}"
+      - run: nix develop -c just build-clean "${{ matrix.profile }}"
+        if: always()
 
   build-darwin:
     needs:
@@ -65,6 +66,10 @@ jobs:
       - run: |
           nix develop -c just build \
             "darwinConfigurations.x86_64.config.system.build.toplevel"
+      - run: |
+          nix develop -c just build-clean \
+            "darwinConfigurations.x86_64.config.system.build.toplevel"
+        if: always()
 
   build-nixos:
     needs:
@@ -85,3 +90,7 @@ jobs:
       - run: |
           nix develop -c just build \
             "nixosConfigurations.x86_64.config.system.build.toplevel"
+      - run: |
+          nix develop -c just build-clean \
+            "nixosConfigurations.x86_64.config.system.build.toplevel"
+        if: always()

--- a/.github/workflows/flake.yaml
+++ b/.github/workflows/flake.yaml
@@ -22,8 +22,6 @@ jobs:
       - uses: actions/checkout@v3
       - run: cachix use "altf4llc-os"
       - run: nix develop -c just check
-      - run: nix develop -c just cache-inputs
-      - run: nix develop -c just cache-shell
 
   build:
     needs:
@@ -46,7 +44,7 @@ jobs:
       - uses: actions/checkout@v4
       - run: cachix use "altf4llc-os"
       - run: |
-          nix develop -c just cache-build "${{ matrix.profile }}"
+          nix develop -c just build "${{ matrix.profile }}"
 
   build-darwin:
     needs:
@@ -65,7 +63,7 @@ jobs:
       - uses: actions/checkout@v4
       - run: cachix use "altf4llc-os"
       - run: |
-          nix develop -c just cache-build \
+          nix develop -c just build \
             "darwinConfigurations.x86_64.config.system.build.toplevel"
 
   build-nixos:
@@ -85,5 +83,5 @@ jobs:
       - uses: actions/checkout@v4
       - run: cachix use "altf4llc-os"
       - run: |
-          nix develop -c just cache-build \
+          nix develop -c just build \
             "nixosConfigurations.x86_64.config.system.build.toplevel"

--- a/.github/workflows/flake.yaml
+++ b/.github/workflows/flake.yaml
@@ -44,8 +44,6 @@ jobs:
       - uses: actions/checkout@v4
       - run: cachix use "altf4llc-os"
       - run: nix develop -c just build "${{ matrix.profile }}"
-      - run: nix develop -c just build-clean "${{ matrix.profile }}"
-        if: always()
 
   build-darwin:
     needs:
@@ -66,10 +64,6 @@ jobs:
       - run: |
           nix develop -c just build \
             "darwinConfigurations.x86_64.config.system.build.toplevel"
-      - run: |
-          nix develop -c just build-clean \
-            "darwinConfigurations.x86_64.config.system.build.toplevel"
-        if: always()
 
   build-nixos:
     needs:
@@ -90,7 +84,3 @@ jobs:
       - run: |
           nix develop -c just build \
             "nixosConfigurations.x86_64.config.system.build.toplevel"
-      - run: |
-          nix develop -c just build-clean \
-            "nixosConfigurations.x86_64.config.system.build.toplevel"
-        if: always()

--- a/.github/workflows/flake.yaml
+++ b/.github/workflows/flake.yaml
@@ -10,10 +10,6 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: shimataro/ssh-key-action@v2
-        with:
-          key: ${{ secrets.DEPLOY_KEY }}
-          known_hosts: unnecessary
       - uses: DeterminateSystems/nix-installer-action@main
       - uses: cachix/cachix-action@v12
         with:
@@ -32,10 +28,6 @@ jobs:
         profile:
           - geist-mono
     steps:
-      - uses: shimataro/ssh-key-action@v2
-        with:
-          key: ${{ secrets.DEPLOY_KEY }}
-          known_hosts: unnecessary
       - uses: DeterminateSystems/nix-installer-action@main
       - uses: cachix/cachix-action@v12
         with:
@@ -50,10 +42,6 @@ jobs:
       - check
     runs-on: macos-latest
     steps:
-      - uses: shimataro/ssh-key-action@v2
-        with:
-          key: ${{ secrets.DEPLOY_KEY }}
-          known_hosts: unnecessary
       - uses: DeterminateSystems/nix-installer-action@main
       - uses: cachix/cachix-action@v12
         with:
@@ -70,10 +58,6 @@ jobs:
       - check
     runs-on: ubuntu-latest
     steps:
-      - uses: shimataro/ssh-key-action@v2
-        with:
-          key: ${{ secrets.DEPLOY_KEY }}
-          known_hosts: unnecessary
       - uses: DeterminateSystems/nix-installer-action@main
       - uses: cachix/cachix-action@v12
         with:

--- a/flake.lock
+++ b/flake.lock
@@ -17,38 +17,6 @@
         "type": "github"
       }
     },
-    "flake-compat": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1673956053,
-        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-compat_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1673956053,
-        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": "nixpkgs-lib"
@@ -83,98 +51,6 @@
         "type": "indirect"
       }
     },
-    "flake-utils": {
-      "locked": {
-        "lastModified": 1659877975,
-        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_2": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_3": {
-      "locked": {
-        "lastModified": 1659877975,
-        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "ghostty": {
-      "inputs": {
-        "nixpkgs-stable": "nixpkgs-stable",
-        "nixpkgs-unstable": "nixpkgs-unstable",
-        "nixpkgs-zig-0-12": "nixpkgs-zig-0-12",
-        "zig": "zig",
-        "zls": "zls"
-      },
-      "locked": {
-        "lastModified": 1710719139,
-        "narHash": "sha256-/0leF3ysUelZcDkgurbzpSzbYp0RXt2B4LJPgkOCmLo=",
-        "ref": "refs/heads/main",
-        "rev": "5dc7384d5731898b9ae5810b1a88d16865be53bf",
-        "revCount": 5258,
-        "type": "git",
-        "url": "ssh://git@github.com/mitchellh/ghostty"
-      },
-      "original": {
-        "type": "git",
-        "url": "ssh://git@github.com/mitchellh/ghostty"
-      }
-    },
-    "gitignore": {
-      "inputs": {
-        "nixpkgs": [
-          "ghostty",
-          "zls",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1694102001,
-        "narHash": "sha256-vky6VPK1n1od6vXbqzOXnekrQpTL4hbPAwUhT5J9c9E=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "9e21c80adf67ebcb077d75bd5e7d724d21eeafd6",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "type": "github"
-      }
-    },
     "home-manager": {
       "inputs": {
         "nixpkgs": [
@@ -193,18 +69,6 @@
         "owner": "nix-community",
         "repo": "home-manager",
         "type": "github"
-      }
-    },
-    "langref": {
-      "flake": false,
-      "locked": {
-        "narHash": "sha256-mYdDCBdNEIeMbavdhSo8qXqW+3fqPC8BAich7W3umrI=",
-        "type": "file",
-        "url": "https://raw.githubusercontent.com/ziglang/zig/63bd2bff12992aef0ce23ae4b344e9cb5d65f05d/doc/langref.html.in"
-      },
-      "original": {
-        "type": "file",
-        "url": "https://raw.githubusercontent.com/ziglang/zig/63bd2bff12992aef0ce23ae4b344e9cb5d65f05d/doc/langref.html.in"
       }
     },
     "nix-darwin": {
@@ -279,54 +143,6 @@
         "type": "github"
       }
     },
-    "nixpkgs-stable": {
-      "locked": {
-        "lastModified": 1702049175,
-        "narHash": "sha256-c/q2+tGHbmLgzT3sXyUKVJR98h1CTks2+nkVaoZPRM0=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "b15508bd65870620f1df5864e8e861dffbc4e428",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "release-23.05",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-unstable": {
-      "locked": {
-        "lastModified": 1688221086,
-        "narHash": "sha256-cdW6qUL71cNWhHCpMPOJjlw0wzSRP0pVlRn2vqX/VVg=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "cd99c2b3c9f160cd004318e0697f90bbd5960825",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-zig-0-12": {
-      "locked": {
-        "lastModified": 1710350178,
-        "narHash": "sha256-vZERN9g+/dfZvSRL9gNBYGVDv/8v7pmXr6LhWYxBgcU=",
-        "owner": "vancluever",
-        "repo": "nixpkgs",
-        "rev": "25322cf4d6b4ffb6f318ab45eab985d1b40e6056",
-        "type": "github"
-      },
-      "original": {
-        "owner": "vancluever",
-        "ref": "vancluever-zig-0-12",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1710806803,
@@ -346,26 +162,10 @@
     "root": {
       "inputs": {
         "flake-parts": "flake-parts",
-        "ghostty": "ghostty",
         "home-manager": "home-manager",
         "nix-darwin": "nix-darwin",
         "nixpkgs": "nixpkgs",
         "thealtf4stream-nvim": "thealtf4stream-nvim"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
       }
     },
     "thealtf4stream-nvim": {
@@ -385,79 +185,6 @@
       "original": {
         "owner": "ALT-F4-LLC",
         "repo": "thealtf4stream.nvim",
-        "type": "github"
-      }
-    },
-    "zig": {
-      "inputs": {
-        "flake-compat": "flake-compat",
-        "flake-utils": "flake-utils",
-        "nixpkgs": [
-          "ghostty",
-          "nixpkgs-stable"
-        ]
-      },
-      "locked": {
-        "lastModified": 1710331756,
-        "narHash": "sha256-ZYFHWEHupxj/e9jOcjUOJLVTuvMR4fYMV53F0zu8Rfs=",
-        "owner": "mitchellh",
-        "repo": "zig-overlay",
-        "rev": "510a1f01f1ddc06df0f2b888f12ad1aa9a65cc31",
-        "type": "github"
-      },
-      "original": {
-        "owner": "mitchellh",
-        "repo": "zig-overlay",
-        "type": "github"
-      }
-    },
-    "zig-overlay": {
-      "inputs": {
-        "flake-compat": "flake-compat_2",
-        "flake-utils": "flake-utils_3",
-        "nixpkgs": [
-          "ghostty",
-          "zls",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1701390337,
-        "narHash": "sha256-C+Lyio+GPl3B2IAZ6Nk5hAAE2g6a8bO9vMACUfOLC/g=",
-        "owner": "mitchellh",
-        "repo": "zig-overlay",
-        "rev": "1815ef2d0451b1121a6a91051da84906fcb06f99",
-        "type": "github"
-      },
-      "original": {
-        "owner": "mitchellh",
-        "repo": "zig-overlay",
-        "type": "github"
-      }
-    },
-    "zls": {
-      "inputs": {
-        "flake-utils": "flake-utils_2",
-        "gitignore": "gitignore",
-        "langref": "langref",
-        "nixpkgs": [
-          "ghostty",
-          "nixpkgs-stable"
-        ],
-        "zig-overlay": "zig-overlay"
-      },
-      "locked": {
-        "lastModified": 1703036566,
-        "narHash": "sha256-GKw+ON8FcUVHxDzA35piev/W/YUvXv5aZ4hmIzNFWuc=",
-        "owner": "zigtools",
-        "repo": "zls",
-        "rev": "adaeabbe1ba888d74309d0a837d4abddc24cf638",
-        "type": "github"
-      },
-      "original": {
-        "owner": "zigtools",
-        "ref": "master",
-        "repo": "zls",
         "type": "github"
       }
     }

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "copilotchat": {
       "flake": false,
       "locked": {
-        "lastModified": 1710849460,
-        "narHash": "sha256-YRfe53MfqmRkgM2YgdYjps1FvhcDeqiSwuPe7YMIM7k=",
+        "lastModified": 1710900281,
+        "narHash": "sha256-Yx6xmw+I3mKTNRCJyTDkXsNGnl+Y0sisYu7kORc7iR4=",
         "owner": "CopilotC-Nvim",
         "repo": "CopilotChat.nvim",
-        "rev": "4811cdd91b35345358da89f0eedd1f2b92c8bf04",
+        "rev": "453b0d54533f6378a188a6afbc10ec087210cad8",
         "type": "github"
       },
       "original": {
@@ -375,11 +375,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1710873156,
-        "narHash": "sha256-TN6YkLtZOuwI7O59QqwL1qVAFdTQUaq8stYRQWOwvVg=",
+        "lastModified": 1710904959,
+        "narHash": "sha256-l71p+TXS0GL98SsFYF1QUPxdNOyZ3Me0+1gqPbMcNfs=",
         "owner": "ALT-F4-LLC",
         "repo": "thealtf4stream.nvim",
-        "rev": "c702814d039d4dacd373859d3a314364c9a205c4",
+        "rev": "bf70facb863379096dc89312db1bcd24cc91df77",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,22 @@
 {
   "nodes": {
+    "copilotchat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1710849460,
+        "narHash": "sha256-YRfe53MfqmRkgM2YgdYjps1FvhcDeqiSwuPe7YMIM7k=",
+        "owner": "CopilotC-Nvim",
+        "repo": "CopilotChat.nvim",
+        "rev": "4811cdd91b35345358da89f0eedd1f2b92c8bf04",
+        "type": "github"
+      },
+      "original": {
+        "owner": "CopilotC-Nvim",
+        "ref": "canary",
+        "repo": "CopilotChat.nvim",
+        "type": "github"
+      }
+    },
     "flake-compat": {
       "flake": false,
       "locked": {
@@ -37,11 +54,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1706830856,
-        "narHash": "sha256-a0NYyp+h9hlb7ddVz4LUn1vT/PLwqfrWYcHMvFB1xYg=",
+        "lastModified": 1709336216,
+        "narHash": "sha256-Dt/wOWeW6Sqm11Yh+2+t0dfEWxoMxGBvv3JpIocFl9E=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "b253292d9c0a5ead9bc98c4e9a26c6312e27d69f",
+        "rev": "f7b3c975cf067e56e7cda6cb098ebe3fb4d74ca2",
         "type": "github"
       },
       "original": {
@@ -54,11 +71,11 @@
         "nixpkgs-lib": "nixpkgs-lib_2"
       },
       "locked": {
-        "lastModified": 1706830856,
-        "narHash": "sha256-a0NYyp+h9hlb7ddVz4LUn1vT/PLwqfrWYcHMvFB1xYg=",
+        "lastModified": 1709336216,
+        "narHash": "sha256-Dt/wOWeW6Sqm11Yh+2+t0dfEWxoMxGBvv3JpIocFl9E=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "b253292d9c0a5ead9bc98c4e9a26c6312e27d69f",
+        "rev": "f7b3c975cf067e56e7cda6cb098ebe3fb4d74ca2",
         "type": "github"
       },
       "original": {
@@ -123,11 +140,11 @@
         "zls": "zls"
       },
       "locked": {
-        "lastModified": 1709081605,
-        "narHash": "sha256-3ACDTMHdB3VlUyov45YkHkVJBkx4NcOkkn0wG2cHXN0=",
+        "lastModified": 1710719139,
+        "narHash": "sha256-/0leF3ysUelZcDkgurbzpSzbYp0RXt2B4LJPgkOCmLo=",
         "ref": "refs/heads/main",
-        "rev": "8881cd6373d4fd7d8b5ea5508b28a9357d9f9311",
-        "revCount": 5214,
+        "rev": "5dc7384d5731898b9ae5810b1a88d16865be53bf",
+        "revCount": 5258,
         "type": "git",
         "url": "ssh://git@github.com/mitchellh/ghostty"
       },
@@ -165,11 +182,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1708988456,
-        "narHash": "sha256-RCz7Xe64tN2zgWk+MVHkzg224znwqknJ1RnB7rVqUWw=",
+        "lastModified": 1710820906,
+        "narHash": "sha256-2bNMraoRB4pdw/HtxgYTFeMhEekBZeQ53/a8xkqpbZc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1d085ea4444d26aa52297758b333b449b2aa6fca",
+        "rev": "022464438a85450abb23d93b91aa82e0addd71fb",
         "type": "github"
       },
       "original": {
@@ -197,11 +214,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1709001452,
-        "narHash": "sha256-FnZ54wkil54hKvr1irdKic1TE27lHQI9dKQmOJRrtlU=",
+        "lastModified": 1710717205,
+        "narHash": "sha256-Wf3gHh5uV6W1TV/A8X8QJf99a5ypDSugY4sNtdJDe0A=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "6c06334f0843c7300d1678726bb607ce526f6b36",
+        "rev": "bcc8afd06e237df060c85bad6af7128e05fd61a3",
         "type": "github"
       },
       "original": {
@@ -212,11 +229,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1708984720,
-        "narHash": "sha256-gJctErLbXx4QZBBbGp78PxtOOzsDaQ+yw1ylNQBuSUY=",
+        "lastModified": 1710806803,
+        "narHash": "sha256-qrxvLS888pNJFwJdK+hf1wpRCSQcqA6W5+Ox202NDa0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "13aff9b34cc32e59d35c62ac9356e4a41198a538",
+        "rev": "b06025f1533a1e07b6db3e75151caa155d1c7eb3",
         "type": "github"
       },
       "original": {
@@ -229,11 +246,11 @@
     "nixpkgs-lib": {
       "locked": {
         "dir": "lib",
-        "lastModified": 1706550542,
-        "narHash": "sha256-UcsnCG6wx++23yeER4Hg18CXWbgNpqNXcHIo5/1Y+hc=",
+        "lastModified": 1709237383,
+        "narHash": "sha256-cy6ArO4k5qTx+l5o+0mL9f5fa86tYUX3ozE1S+Txlds=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "97b17f32362e475016f942bbdfda4a4a72a8a652",
+        "rev": "1536926ef5621b09bba54035ae2bb6d806d72ac8",
         "type": "github"
       },
       "original": {
@@ -247,11 +264,11 @@
     "nixpkgs-lib_2": {
       "locked": {
         "dir": "lib",
-        "lastModified": 1706550542,
-        "narHash": "sha256-UcsnCG6wx++23yeER4Hg18CXWbgNpqNXcHIo5/1Y+hc=",
+        "lastModified": 1709237383,
+        "narHash": "sha256-cy6ArO4k5qTx+l5o+0mL9f5fa86tYUX3ozE1S+Txlds=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "97b17f32362e475016f942bbdfda4a4a72a8a652",
+        "rev": "1536926ef5621b09bba54035ae2bb6d806d72ac8",
         "type": "github"
       },
       "original": {
@@ -296,11 +313,11 @@
     },
     "nixpkgs-zig-0-12": {
       "locked": {
-        "lastModified": 1709060268,
-        "narHash": "sha256-IGt0MDqdojBXdE97ORxL2Pk5x4GHFEOc3G7tjsMXLfU=",
+        "lastModified": 1710350178,
+        "narHash": "sha256-vZERN9g+/dfZvSRL9gNBYGVDv/8v7pmXr6LhWYxBgcU=",
         "owner": "vancluever",
         "repo": "nixpkgs",
-        "rev": "c7dc015475bd4ac5de01a04680aa08777879add1",
+        "rev": "25322cf4d6b4ffb6f318ab45eab985d1b40e6056",
         "type": "github"
       },
       "original": {
@@ -312,11 +329,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1708984720,
-        "narHash": "sha256-gJctErLbXx4QZBBbGp78PxtOOzsDaQ+yw1ylNQBuSUY=",
+        "lastModified": 1710806803,
+        "narHash": "sha256-qrxvLS888pNJFwJdK+hf1wpRCSQcqA6W5+Ox202NDa0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "13aff9b34cc32e59d35c62ac9356e4a41198a538",
+        "rev": "b06025f1533a1e07b6db3e75151caa155d1c7eb3",
         "type": "github"
       },
       "original": {
@@ -353,15 +370,16 @@
     },
     "thealtf4stream-nvim": {
       "inputs": {
+        "copilotchat": "copilotchat",
         "flake-parts": "flake-parts_2",
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1709098824,
-        "narHash": "sha256-rmzXtEnRZqZ9NChViJrvmfKDv8QJaKATYAR6RQVIhP0=",
+        "lastModified": 1710873156,
+        "narHash": "sha256-TN6YkLtZOuwI7O59QqwL1qVAFdTQUaq8stYRQWOwvVg=",
         "owner": "ALT-F4-LLC",
         "repo": "thealtf4stream.nvim",
-        "rev": "14887bd279718751208ba3554aa075e28f3a1434",
+        "rev": "c702814d039d4dacd373859d3a314364c9a205c4",
         "type": "github"
       },
       "original": {
@@ -380,11 +398,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1709035693,
-        "narHash": "sha256-ac5fR8n4RPjP5GHhFMdtUhdL6e/eFCxIOO+7UoP1B/g=",
+        "lastModified": 1710331756,
+        "narHash": "sha256-ZYFHWEHupxj/e9jOcjUOJLVTuvMR4fYMV53F0zu8Rfs=",
         "owner": "mitchellh",
         "repo": "zig-overlay",
-        "rev": "e1c418c2315adaeca6f27fd8919141eb7992866d",
+        "rev": "510a1f01f1ddc06df0f2b888f12ad1aa9a65cc31",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,6 @@
   description = "Development packages and systems for TheAltF4Stream";
 
   inputs = {
-    ghostty.url = "git+ssh://git@github.com/mitchellh/ghostty";
     home-manager.inputs.nixpkgs.follows = "nixpkgs";
     home-manager.url = "github:nix-community/home-manager";
     nix-darwin.inputs.nixpkgs.follows = "nixpkgs";

--- a/flake.nix
+++ b/flake.nix
@@ -42,17 +42,19 @@
         pkgs,
         system,
         ...
-      }: {
+      }: let
+        inherit (pkgs) callPackage alejandra just mkShell;
+      in {
         devShells = {
-          default = pkgs.mkShell {
-            nativeBuildInputs = [pkgs.just];
+          default = mkShell {
+            nativeBuildInputs = [just];
           };
         };
 
-        formatter = pkgs.alejandra;
+        formatter = alejandra;
 
         packages = {
-          geist-mono = self.lib.geist-mono {inherit (pkgs) fetchzip lib stdenvNoCC;};
+          geist-mono = callPackage self.lib.geist-mono {};
         };
       };
     };

--- a/justfile
+++ b/justfile
@@ -4,18 +4,6 @@ _default:
 build profile:
     nix build --json --no-link --print-build-logs ".#{{ profile }}"
 
-cache-build profile cache_name="altf4llc-os":
-    just build "{{ profile }}" | jq -r '.[].outputs | to_entries[].value' | cachix push {{ cache_name }}
-
-cache-inputs cache_name="altf4llc-os":
-    nix flake archive --json \
-      | jq -r '.path,(.inputs|to_entries[].value.path)' \
-      | cachix push "{{ cache_name }}"
-
-cache-shell cache_name="altf4llc-os":
-    nix develop --profile "dev-profile" -c true
-    cachix push "{{ cache_name }}" "dev-profile"
-
 check:
     nix flake check
 

--- a/justfile
+++ b/justfile
@@ -4,6 +4,9 @@ _default:
 build profile:
     nix build --json --no-link --print-build-logs ".#{{ profile }}"
 
+build-clean profile:
+    nix store delete $(nix path-info --recursive '.#{{ profile }}')
+
 check:
     nix flake check
 

--- a/justfile
+++ b/justfile
@@ -4,9 +4,6 @@ _default:
 build profile:
     nix build --json --no-link --print-build-logs ".#{{ profile }}"
 
-build-clean profile:
-    nix store delete $(nix path-info --recursive '.#{{ profile }}')
-
 check:
     nix flake check
 

--- a/lib/nixos/home-manager.nix
+++ b/lib/nixos/home-manager.nix
@@ -11,7 +11,6 @@ in {
   #---------------------------------------------------------------------
 
   home.file.".config/k9s/skin.yml".source = ../../config/k9s/skin.yml;
-  home.packages = pkgs.lib.optionals desktop [pkgs.jetbrains.datagrip];
 
   #---------------------------------------------------------------------
   # programs

--- a/lib/nixos/home-manager.nix
+++ b/lib/nixos/home-manager.nix
@@ -27,6 +27,5 @@ in {
     defaultCacheTtl = 31536000; # cache keys forever don't get asked for password
     enable = true;
     maxCacheTtl = 31536000;
-    pinentryFlavor = "tty";
   };
 }

--- a/lib/shared/home-manager.nix
+++ b/lib/shared/home-manager.nix
@@ -151,6 +151,7 @@ in {
       extraConfig = {
         color.ui = true;
         commit.gpgsign = true;
+        core.editor = "nvim";
         diff.colorMoved = "zebra";
         fetch.prune = true;
         init.defaultBranch = "main";
@@ -292,7 +293,7 @@ in {
 
   programs.zsh = {
     enable = true;
-    enableAutosuggestions = true;
+    autosuggestion.enable = true;
     enableCompletion = true;
 
     initExtra = ''

--- a/lib/shared/home-manager.nix
+++ b/lib/shared/home-manager.nix
@@ -323,8 +323,8 @@ in {
 
     shellAliases = {
       cat = "bat";
-      cpm = ''git diff --staged | s -- sgpt --md "Generate git commit message using latest conventional commit methods"'';
-      cpr = ''git diff $(git merge-base main $(git branch --show-current))..HEAD | s -- sgpt --code "Generate short and concise conventional PR title and description for GitHub of the changes in markdown"'';
+      cpm = ''git diff --staged | s -- sgpt --code "Generate a commit message using conventional commit specifiction"'';
+      cpr = ''git diff $(git merge-base main $(git branch --show-current))..HEAD | s -- sgpt --code "Generate short and concise PR title and description for GitHub of the changes in markdown using conventional commit specification"'';
       dr = "docker container run --interactive --rm --tty";
       lg = "lazygit";
       ll =

--- a/lib/shared/home-manager.nix
+++ b/lib/shared/home-manager.nix
@@ -323,7 +323,7 @@ in {
 
     shellAliases = {
       cat = "bat";
-      cpm = ''git diff --staged | sgpt --code --no-cache "Generate a commit message using conventional commit specifiction (DO NOT GENERATE A COMMAND)" | git commit -F -'';
+      cpm = ''git diff --staged | sgpt --code --no-cache "Generate a commit message describing the changes using conventional commit specifiction (DO NOT GENERATE A COMMAND)" | git commit -F -'';
       cpr = ''git diff $(git merge-base main $(git branch --show-current))..HEAD | s -- sgpt --code "Generate short PR title and description for GitHub of the changes in markdown using conventional commit specification"'';
       dr = "docker container run --interactive --rm --tty";
       lg = "lazygit";

--- a/lib/shared/home-manager.nix
+++ b/lib/shared/home-manager.nix
@@ -20,25 +20,21 @@ in {
     theme = TokyoNight
   '';
 
-  home.packages = with pkgs;
-    [
-      awscli2
-      cachix
-      doppler
-      fd
-      gh
-      git-remote-codecommit
-      jq
-      k9s
-      kubectl
-      lazydocker
-      ripgrep
-      shell_gpt
-      z-lua
-    ]
-    ++ lib.lists.optionals isLinux [
-      inputs.ghostty.packages.${pkgs.system}.default
-    ];
+  home.packages = with pkgs; [
+    awscli2
+    cachix
+    doppler
+    fd
+    gh
+    git-remote-codecommit
+    jq
+    k9s
+    kubectl
+    lazydocker
+    ripgrep
+    shell_gpt
+    z-lua
+  ];
 
   home.sessionVariables = {
     CHARM_HOST = "localhost";

--- a/lib/shared/home-manager.nix
+++ b/lib/shared/home-manager.nix
@@ -13,33 +13,11 @@ in {
 
   home.file.".config/ghostty/config".text = ''
     # settings
-    background = 161616
     background-opacity = 0.9
-    cursor-color = f2f4f8
-    font-family = "GeistMono NFM"
-    font-size = 18
-    foreground = dde1e6
+    font-family = GeistMono NFM
+    font-size = 20
     macos-option-as-alt = true
-    selection-background = 525252
-    selection-foreground = f2f4f8
-
-    # theme
-    palette = 0=#262626
-    palette = 1=#ff7eb6
-    palette = 2=#42be65
-    palette = 3=#82cfff
-    palette = 4=#33b1ff
-    palette = 5=#ee5396
-    palette = 6=#3ddbd9
-    palette = 7=#dde1e6
-    palette = 8=#393939
-    palette = 9=#ff7eb6
-    palette = 10=#42be65
-    palette = 11=#82cfff
-    palette = 12=#33b1ff
-    palette = 13=#ee5396
-    palette = 14=#3ddbd9
-    palette = 15=#ffffff
+    theme = TokyoNight
   '';
 
   home.packages = with pkgs;
@@ -55,6 +33,7 @@ in {
       kubectl
       lazydocker
       ripgrep
+      shell_gpt
       z-lua
     ]
     ++ lib.lists.optionals isLinux [
@@ -63,6 +42,7 @@ in {
 
   home.sessionVariables = {
     CHARM_HOST = "localhost";
+    DEFAULT_MODEL = "gpt-4-turbo-preview";
     DOTNET_CLI_TELEMETRY_OPTOUT = "true";
     EDITOR = "nvim";
     LANG = "en_US.UTF-8";
@@ -343,6 +323,8 @@ in {
 
     shellAliases = {
       cat = "bat";
+      cpm = ''git diff --staged | s -- sgpt --md "Generate git commit message using latest conventional commit methods"'';
+      cpr = ''git diff $(git merge-base main $(git branch --show-current))..HEAD | s -- sgpt --code "Generate short and concise conventional PR title and description for GitHub of the changes in markdown"'';
       dr = "docker container run --interactive --rm --tty";
       lg = "lazygit";
       ll =

--- a/lib/shared/home-manager.nix
+++ b/lib/shared/home-manager.nix
@@ -61,18 +61,18 @@ in {
 
   programs.bat = {
     enable = true;
-    config = {theme = "catppuccin";};
+    config = {theme = "tokyonight";};
     themes = {
-      catppuccin = {
+      tokyonight = {
         src =
           pkgs.fetchFromGitHub
           {
-            owner = "catppuccin";
-            repo = "bat";
-            rev = "ba4d16880d63e656acced2b7d4e034e4a93f74b1";
-            sha256 = "sha256-6WVKQErGdaqb++oaXnY3i6/GuH2FhTgK0v4TN4Y0Wbw=";
+            owner = "folke";
+            repo = "tokyonight.nvim";
+            rev = "c025baf23b62f044eff1f4ef561c45de636f0e32";
+            sha256 = "sha256-wG4rQ4o8Q1wcsQvha/4EKRvQ1rvguU5W34h7JMSKpek=";
           };
-        file = "Catppuccin-macchiato.tmTheme";
+        file = "extras/sublime/tokyonight_night.tmTheme";
       };
     };
   };
@@ -154,53 +154,24 @@ in {
       package = inputs.self.packages.${pkgs.system}.geist-mono;
       size =
         if isDarwin
-        then 18
-        else 15;
+        then 20
+        else 18;
     };
 
     settings = {
-      active_border_color = "#ee5396";
-      active_tab_background = "#ee5396";
-      active_tab_foreground = "#161616";
       allow_remote_control = "yes";
-      background = "#161616";
       background_opacity = "0.9";
-      bell_border_color = "#ee5396";
-      color0 = "#262626";
-      color1 = "#ff7eb6";
-      color10 = "#42be65";
-      color11 = "#82cfff";
-      color12 = "#33b1ff";
-      color13 = "#ee5396";
-      color14 = "#3ddbd9";
-      color15 = "#ffffff";
-      color2 = "#42be65";
-      color3 = "#82cfff";
-      color4 = "#33b1ff";
-      color5 = "#ee5396";
-      color6 = "#3ddbd9";
-      color7 = "#dde1e6";
-      color8 = "#393939";
-      color9 = "#ff7eb6";
-      cursor = "#f2f4f8";
-      cursor_text_color = "#393939";
       enabled_layouts = "splits";
-      foreground = "#dde1e6";
       hide_window_decorations = "titlebar-and-corners";
-      inactive_border_color = "#ff7eb6";
-      inactive_tab_background = "#393939";
-      inactive_tab_foreground = "#dde1e6";
       listen_on = "unix:/tmp/kitty";
       macos_option_as_alt = "yes";
       macos_quit_when_last_window_closed = "yes";
       macos_titlebar_color = "system";
-      selection_background = "#525252";
-      selection_foreground = "#f2f4f8";
-      tab_bar_background = "#161616";
-      url_color = "#ee5396";
       url_style = "single";
       wayland_titlebar_color = "system";
     };
+
+    theme = "Tokyo Night";
   };
 
   programs.lazygit = {
@@ -333,6 +304,7 @@ in {
         else "n -P K";
       nb = "nix build --json --no-link --print-build-logs";
       s = ''doppler run --config "nixos" --project "$(whoami)"'';
+      sgpt = "s -- sgpt --no-cache";
       wt = "git worktree";
     };
 

--- a/lib/shared/home-manager.nix
+++ b/lib/shared/home-manager.nix
@@ -324,7 +324,7 @@ in {
     shellAliases = {
       cat = "bat";
       cpm = ''git diff --staged | s -- sgpt --code --no-cache "Generate a git commit message describing the changes using the conventional commit specifiction (DO NOT GENERATE A COMMAND)" | git commit -F -'';
-      cpr = ''git diff $(git merge-base main $(git branch --show-current))..HEAD | s -- sgpt --code --no-cache "Generate a 30 character max GitHub PR title and short and concise grouped lists of changes using symver specification in markdown"'';
+      cpr = ''git diff $(git merge-base main $(git branch --show-current))..HEAD | s -- sgpt --code --no-cache "Generate a 30 character max GitHub Pull Request title and description that includes only categorized lists (added, removed, etc) using symver specification in markdown. Do not include git diff output."'';
       dr = "docker container run --interactive --rm --tty";
       lg = "lazygit";
       ll =

--- a/lib/shared/home-manager.nix
+++ b/lib/shared/home-manager.nix
@@ -323,8 +323,8 @@ in {
 
     shellAliases = {
       cat = "bat";
-      cpm = ''git diff --staged | sgpt --code --no-cache "Generate a commit message describing the changes using conventional commit specifiction (DO NOT GENERATE A COMMAND)" | git commit -F -'';
-      cpr = ''git diff $(git merge-base main $(git branch --show-current))..HEAD | s -- sgpt --code "Generate short PR title and description for GitHub of the changes in markdown using conventional commit specification"'';
+      cpm = ''git diff --staged | s -- sgpt --code --no-cache "Generate a commit message describing the changes using conventional commit specifiction (DO NOT GENERATE A COMMAND)" | git commit -F -'';
+      cpr = ''git diff $(git merge-base main $(git branch --show-current))..HEAD | s -- sgpt --code --no-cache "Generate a 30 character max GitHub PR title and short and concise grouped lists of changes using symver specification in markdown"'';
       dr = "docker container run --interactive --rm --tty";
       lg = "lazygit";
       ll =

--- a/lib/shared/home-manager.nix
+++ b/lib/shared/home-manager.nix
@@ -323,7 +323,7 @@ in {
 
     shellAliases = {
       cat = "bat";
-      cpm = ''git diff --staged | s -- sgpt --code --no-cache "Generate a commit message describing the changes using conventional commit specifiction (DO NOT GENERATE A COMMAND)" | git commit -F -'';
+      cpm = ''git diff --staged | s -- sgpt --code --no-cache "Generate a git commit message describing the changes using the conventional commit specifiction (DO NOT GENERATE A COMMAND)" | git commit -F -'';
       cpr = ''git diff $(git merge-base main $(git branch --show-current))..HEAD | s -- sgpt --code --no-cache "Generate a 30 character max GitHub PR title and short and concise grouped lists of changes using symver specification in markdown"'';
       dr = "docker container run --interactive --rm --tty";
       lg = "lazygit";

--- a/lib/shared/home-manager.nix
+++ b/lib/shared/home-manager.nix
@@ -323,7 +323,7 @@ in {
 
     shellAliases = {
       cat = "bat";
-      cpm = ''git diff --staged | s -- sgpt "Generate a commit message using conventional commit specifiction"'';
+      cpm = ''git diff --staged | sgpt --code --no-cache "Generate a commit message using conventional commit specifiction (DO NOT GENERATE A COMMAND)" | git commit -F -'';
       cpr = ''git diff $(git merge-base main $(git branch --show-current))..HEAD | s -- sgpt --code "Generate short PR title and description for GitHub of the changes in markdown using conventional commit specification"'';
       dr = "docker container run --interactive --rm --tty";
       lg = "lazygit";

--- a/lib/shared/home-manager.nix
+++ b/lib/shared/home-manager.nix
@@ -323,8 +323,8 @@ in {
 
     shellAliases = {
       cat = "bat";
-      cpm = ''git diff --staged | s -- sgpt --code "Generate a commit message using conventional commit specifiction"'';
-      cpr = ''git diff $(git merge-base main $(git branch --show-current))..HEAD | s -- sgpt --code "Generate short and concise PR title and description for GitHub of the changes in markdown using conventional commit specification"'';
+      cpm = ''git diff --staged | s -- sgpt "Generate a commit message using conventional commit specifiction"'';
+      cpr = ''git diff $(git merge-base main $(git branch --show-current))..HEAD | s -- sgpt --code "Generate short PR title and description for GitHub of the changes in markdown using conventional commit specification"'';
       dr = "docker container run --interactive --rm --tty";
       lg = "lazygit";
       ll =


### PR DESCRIPTION
### Added
- Use `nix develop -c just build` directly in workflows for simplicity.

### Removed
- Removed SSH key setup steps in GitHub Actions workflows.
- Removed caching steps in GitHub Actions workflows.
- Cleaned up `flake.lock` by removing unused inputs and updating existing ones.
- Removed JetBrains DataGrip from Home Manager configuration.
- Simplified `home-manager.nix` and `shared/home-manager.nix` configurations.
- Removed ghostty and related configurations.

### Changed
- Updated `justfile` to remove caching commands.
- Updated Home Manager and shared configurations for simplicity and modernization.
- Switched to using `callPackage` and direct attribute access in `flake.nix`.
- Updated themes and configurations to use Tokyo Night and simplified settings.